### PR TITLE
Fixed misspelled name in The Team dropdown menu

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -18,7 +18,7 @@
             <li><a href="https://devpointlabs.slack.com/team/evjay" target="_blank">Evan</a></li>
             <li><a href="https://devpointlabs.slack.com/team/lindsayhammon" target="_blank">Lindsay</a></li>
             <li><a href="https://devpointlabs.slack.com/team/zcid" target="_blank">Nick H.</a></li>
-            <li><a href="https://devpointlabs.slack.com/team/annenichols" target="_blank">Ann</a></li>
+            <li><a href="https://devpointlabs.slack.com/team/annenichols" target="_blank">Anne</a></li>
             <li><a href="https://devpointlabs.slack.com/team/amandawalter" target="_blank">Amanda</a></li>
             <li><a href="https://devpointlabs.slack.com/team/topher" target="_blank">Topher</a></li>
             <li><a href="https://devpointlabs.slack.com/team/markymarrk" target="_blank">Marcos</a></li>


### PR DESCRIPTION
My name was misspelled in the dropdown menu. I fixed it. Because I'm vain. 